### PR TITLE
Fix bug in showModal

### DIFF
--- a/js/jquery.modalEffects.js
+++ b/js/jquery.modalEffects.js
@@ -186,7 +186,7 @@
               mod.css({'perspective':'none'});
               
               //3D Blur Bug Fix
-              if(modal.height() % 2 != 0){modal.css({'height':modal.height() + 1});}
+              if(mod.height() % 2 != 0){mod.css({'height':mod.height() + 1});}
 
             }, 500 ); 
             


### PR DESCRIPTION
There was a bug in showModal function. showModal takes parameter 'mod', but in 3D Blur Bug Fix it is referenced as modal.
